### PR TITLE
Make debug instrumentation configurable and resettable

### DIFF
--- a/src/tests.py
+++ b/src/tests.py
@@ -1,6 +1,27 @@
+import argparse
+from collections.abc import Callable
+
 import numpy as np
 
 from neurrayv4 import U1XToU1X
+
+
+def format_debug_stats(neur: U1XToU1X, prefix: str = "debug") -> str:
+    stats = neur.debug_snapshot()
+    return (
+        f"[{prefix}] calls={stats['forward_calls']} "
+        f"inputs={stats['total_inputs']} "
+        f"diffs={stats['total_diffs']} "
+        f"cases={stats['active_cases']} "
+        f"avg_diffs/input={stats['avg_diffs_per_input']:.4f} "
+        f"avg_case_acts/input={stats['avg_case_activations_per_input']:.4f} "
+        f"mean_acts/case={stats['mean_activations_per_case']:.2f}"
+    )
+
+
+def print_debug_stats(neur: U1XToU1X, prefix: str = "debug") -> None:
+    print(format_debug_stats(neur, prefix=prefix))
+
 
 def sanity_test():
 
@@ -21,7 +42,11 @@ def sanity_test():
 
 
 
-def dataset():
+def dataset(
+    report_every: int = 1000,
+    reporter: Callable[[str], None] | None = print,
+    reset_stats_between_stages: bool = True,
+):
     import tensorflow_datasets as tfds
 
     # load full dataset
@@ -82,7 +107,8 @@ def dataset():
 
     all_tiles_train = tiles_train.reshape(tiles_train.shape[0] * tiles_train.shape[1], tiles_train.shape[2])
     all_tiles = np.unique(all_tiles_train, axis=0)
-    print(f"{all_tiles.shape[0]} total unique tiles")
+    if reporter:
+        reporter(f"{all_tiles.shape[0]} total unique tiles")
     # 1972878 tiles as is
 
     # we love setup being 4 seconds out of 28 second runtime on the poor laptop
@@ -92,32 +118,70 @@ def dataset():
     counter = 0
 
     for tile in tiles_train:
-        if counter % 1000 == 0:
-            print(f"training at: {counter}")
+        if reporter and report_every > 0 and counter % report_every == 0:
+            reporter(f"training at: {counter}")
+            reporter(format_debug_stats(neur, prefix="train"))
         rev = neur.forward(tile)
         try:
             neur.assign(rev)
         except AssertionError:
-            print(f"Broke at: {counter}, ran out out of cases\n")
+            if reporter:
+                reporter(f"Broke at: {counter}, ran out out of cases\n")
             raise
         counter += 1
-    print(f"\n\n{neur.array_used} cases used!\nMoving into validation\n")
+
+    if reporter:
+        reporter(format_debug_stats(neur, prefix="train-final"))
+        reporter(f"\n\n{neur.array_used} cases used!\nMoving into validation\n")
     # 811 as is
+
+    if reset_stats_between_stages:
+        neur.reset_debug_stats()
 
     counter = 0
     misses = 0
     for tile in tiles_eval:
-        if counter % 1000 == 0:
-            print(f"eval at: {counter}")
+        if reporter and report_every > 0 and counter % report_every == 0:
+            reporter(f"eval at: {counter}")
+            reporter(format_debug_stats(neur, prefix="eval"))
         rev = neur.forward(tile)
         misses += rev.shape[0]
         counter += 1
 
-    print(f"\n\n{misses} inputs were unable to be mapped for eval")
+    if reporter:
+        reporter(format_debug_stats(neur, prefix="eval-final"))
+        reporter(f"\n\n{misses} inputs were unable to be mapped for eval")
     # 0 as is
 
+    return neur, misses
 
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Run NN structural engine diagnostics")
+    parser.add_argument("--mode", choices=("dataset", "sanity"), default="dataset")
+    parser.add_argument(
+        "--report-every",
+        type=int,
+        default=1000,
+        help="Emit periodic debug logs every N batches; set to 0 to disable periodic logs.",
+    )
+    parser.add_argument(
+        "--no-reset-between-stages",
+        action="store_true",
+        help="Keep debug counters cumulative across training and evaluation.",
+    )
+    args = parser.parse_args()
+
+    if args.mode == "sanity":
+        sanity_test()
+        return
+
+    dataset(
+        report_every=args.report_every,
+        reporter=print,
+        reset_stats_between_stages=not args.no_reset_between_stages,
+    )
 
 
 if __name__ == "__main__":
-    dataset()
+    main()


### PR DESCRIPTION
### Motivation
- The previous dataset runner hardcoded debug printing and made it difficult to run isolated tests or reuse the debug output programmatically. 
- Tests and evaluation should be able to control logging cadence and destination without editing core code. 
- Debug counters must be resettable so statistics can be scoped (for example, reset between training and evaluation) to avoid misleading cumulative metrics.

### Description
- Add `reset_debug_stats()` and initialize debug counters via that function so stats can be zeroed without rebuilding the `U1XToU1X` instance. 
- Preserve the existing metrics (`forward_calls`, `total_inputs`, `total_diffs`, `total_case_activations`, `debug_case_activations`) while moving their lifecycle control into the reset API. 
- Introduce `format_debug_stats()` to return a single-line debug string and keep `print_debug_stats()` as a thin wrapper, allowing callers to capture or route debug output. 
- Make the dataset runner configurable with `report_every`, `reporter` callback, and `reset_stats_between_stages` parameters and add a CLI entrypoint (`--mode`, `--report-every`, `--no-reset-between-stages`) so runs are scriptable and testable.

### Testing
- Ran a small assertions check that exercises `format_debug_stats()` and `reset_debug_stats()` with `PYTHONPATH=src python - <<'PY' ...` and it succeeded. 
- Executed the bundled `sanity_test()` via `PYTHONPATH=src python - <<'PY' from tests import sanity_test; sanity_test()` and observed the expected case counts (`3`, `4`, `4`). 
- Ran the CLI sanity mode with `PYTHONPATH=src python src/tests.py --mode sanity` and the script completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699114ebeaa48325b79b25f07dcf802c)