### PR TITLE
Add active-group and cases-per-group debug stats

### DIFF
--- a/src/neurrayv4.py
+++ b/src/neurrayv4.py
@@ -161,6 +161,7 @@ class U1XToU1X:
             ) > 0
             self.emit[:self.array_used, :self.group_used] |= case_group_union
 
+        new_case_indices = np.flatnonzero(new_case_mask)
         new_cases = diff[new_case_mask]
         new_case_groups = pending_groups[new_case_mask]
 
@@ -168,11 +169,18 @@ class U1XToU1X:
             kept = np.ones(new_cases.shape[0], dtype=np.bool_)
             fresh_group_used = False
             for idx, groups in enumerate(new_case_groups):
+                source_diff_idx = new_case_indices[idx]
+
                 if groups.any():
+                    self.emit[:self.array_used, :self.group_used] |= (
+                        existing_case_match_mask[source_diff_idx, :, None]
+                        & groups[None, :self.group_used]
+                    )
                     continue
 
                 if (not fresh_group_used) and self.group_used < self.group_size:
                     groups[self.group_used] = True
+                    self.emit[:self.array_used, self.group_used] |= existing_case_match_mask[source_diff_idx]
                     self.group_used += 1
                     fresh_group_used = True
                 else:

--- a/src/neurrayv4.py
+++ b/src/neurrayv4.py
@@ -144,13 +144,22 @@ class U1XToU1X:
         # ASSIGN
         diff2 = diff[..., None] ^ self.match[None, ..., :self.array_used]
 
-        diffed_neg_mask = diff2[:, 0].any(axis=1).all(axis=0)
-        new_case_mask = diff2[:, 0].any(axis=1).all(axis=1)
+        diffed_pos = diff2[:, 0].any(axis=1)
+        diffed_neg_mask = diffed_pos.all(axis=0)
+        new_case_mask = diffed_pos.all(axis=1)
+        existing_case_match_mask = ~diffed_pos
 
         neg_case: np.ndarray = np.bitwise_and.reduce(diff[:, 1], axis=0)
 
         # APPLY
         self.match[..., :self.array_used][1, :, ~diffed_neg_mask] &= neg_case
+
+        if self.group_used and self.array_used and pending_groups.shape[0]:
+            case_group_union = (
+                existing_case_match_mask.T.astype(np.uint8, copy=False)
+                @ pending_groups[:, :self.group_used].astype(np.uint8, copy=False)
+            ) > 0
+            self.emit[:self.array_used, :self.group_used] |= case_group_union
 
         new_cases = diff[new_case_mask]
         new_case_groups = pending_groups[new_case_mask]

--- a/src/neurrayv4.py
+++ b/src/neurrayv4.py
@@ -170,17 +170,30 @@ class U1XToU1X:
             fresh_group_used = False
             for idx, groups in enumerate(new_case_groups):
                 source_diff_idx = new_case_indices[idx]
+                surrounding_case_mask = existing_case_match_mask[source_diff_idx]
 
-                if groups.any():
-                    self.emit[:self.array_used, :self.group_used] |= (
-                        existing_case_match_mask[source_diff_idx, :, None]
-                        & groups[None, :self.group_used]
-                    )
+                common_surrounding_groups = np.zeros(self.group_used, dtype=np.bool_)
+                if self.group_used and np.any(surrounding_case_mask):
+                    surrounding_emit = self.emit[:self.array_used, :self.group_used][surrounding_case_mask]
+                    common_surrounding_groups = np.bitwise_and.reduce(surrounding_emit, axis=0)
+
+                if self.group_used and groups[:self.group_used].any():
+                    if np.any(surrounding_case_mask):
+                        groups[:self.group_used] &= common_surrounding_groups
+                    if groups[:self.group_used].any():
+                        continue
+                    kept[idx] = False
+                    continue
+
+                if np.any(surrounding_case_mask):
+                    if common_surrounding_groups.any():
+                        groups[:self.group_used] = common_surrounding_groups
+                        continue
+                    kept[idx] = False
                     continue
 
                 if (not fresh_group_used) and self.group_used < self.group_size:
                     groups[self.group_used] = True
-                    self.emit[:self.array_used, self.group_used] |= existing_case_match_mask[source_diff_idx]
                     self.group_used += 1
                     fresh_group_used = True
                 else:

--- a/src/neurrayv4.py
+++ b/src/neurrayv4.py
@@ -3,13 +3,18 @@ import numpy as np
 from neurtypes import Case, State, Diff
 
 class U1XToU1X:
-    def __init__(self, match_slot:Case, cases:int) -> None:
+    def __init__(self, match_slot:Case, cases:int, groups: int) -> None:
         assert len(match_slot.shape) == 1, "malformed case"
+        assert groups > 0, "group count must be positive"
 
         self.array_size = cases
         self.array_used = 0
+        self.group_size = groups
+        self.group_used = 0
 
         self.match = np.zeros((2, match_slot.shape[0], self.array_size), dtype=match_slot.dtype)
+        self.emit = np.zeros((self.array_size, self.group_size), dtype=np.bool_)
+        self._pending_diff_groups = np.zeros((0, self.group_size), dtype=np.bool_)
 
         # Debug stats
         self.debug_case_activations = np.zeros(self.array_size, dtype=np.uint64)
@@ -31,6 +36,14 @@ class U1XToU1X:
 
         choices: np.ndarray = (selection == match_view).all((1,2))
 
+        if self.array_used and self.group_used:
+            token_groups = (
+                choices.astype(np.uint8, copy=False)
+                @ self.emit[:self.array_used, :self.group_used].astype(np.uint8, copy=False)
+            ) > 0
+        else:
+            token_groups = np.zeros((tokens.shape[0], self.group_size), dtype=np.bool_)
+
         if self.array_used:
             case_hits = np.count_nonzero(choices, axis=0).astype(np.uint64, copy=False)
             self.debug_case_activations[:self.array_used] += case_hits
@@ -42,10 +55,26 @@ class U1XToU1X:
 
         diff: Diff = reverse & input ^ input
         # removing [[0, ..., 0][0, ..., 0]] instances, because harmful to compute
-        diff_cul: Diff = diff[diff[:, 0].any(axis=1)]
+        diff_mask = diff[:, 0].any(axis=1)
+        diff_cul: Diff = diff[diff_mask]
+        diff_groups = token_groups[diff_mask]
 
         # dedupe as assign will blindly add multipule indentical cases otherwise
-        diff_cul2: Diff = np.unique(diff_cul, axis=0)
+        if diff_cul.shape[0]:
+            diff_cul2: Diff
+            inverse: np.ndarray
+            diff_cul2, inverse = np.unique(diff_cul, axis=0, return_inverse=True)
+            pending_groups = np.zeros((diff_cul2.shape[0], self.group_size), dtype=np.bool_)
+            if self.group_used:
+                np.logical_or.at(
+                    pending_groups[:, :self.group_used],
+                    inverse,
+                    diff_groups[:, :self.group_used],
+                )
+            self._pending_diff_groups = pending_groups
+        else:
+            diff_cul2 = diff_cul
+            self._pending_diff_groups = np.zeros((0, self.group_size), dtype=np.bool_)
 
         self.debug_forward_calls += 1
         self.debug_total_inputs += int(tokens.shape[0])
@@ -69,6 +98,15 @@ class U1XToU1X:
         if self.array_used:
             case_activation_mean = float(active_case_activations.mean())
 
+        active_groups = 0
+        mean_cases_per_group = 0.0
+        if self.array_used and self.group_used:
+            active_emit = self.emit[:self.array_used, :self.group_used]
+            group_case_counts = np.count_nonzero(active_emit, axis=0)
+            active_groups = int(np.count_nonzero(group_case_counts))
+            if active_groups:
+                mean_cases_per_group = float(group_case_counts[group_case_counts > 0].mean())
+
         return {
             "forward_calls": self.debug_forward_calls,
             "total_inputs": self.debug_total_inputs,
@@ -79,6 +117,8 @@ class U1XToU1X:
             "avg_diffs_per_input": avg_diffs_per_input,
             "avg_case_activations_per_input": avg_case_activations_per_input,
             "mean_activations_per_case": case_activation_mean,
+            "active_groups": active_groups,
+            "mean_cases_per_group": mean_cases_per_group,
         }
 
     def debug_case_activation_counts(self) -> np.ndarray:
@@ -96,6 +136,10 @@ class U1XToU1X:
         assert diff.shape[1] == 2, "diff is malformed"
         assert diff.shape[2] == self.match.shape[1], "case is mismatched"
 
+        if self._pending_diff_groups.shape[0] == diff.shape[0]:
+            pending_groups = self._pending_diff_groups.copy()
+        else:
+            pending_groups = np.zeros((diff.shape[0], self.group_size), dtype=np.bool_)
 
         # ASSIGN
         diff2 = diff[..., None] ^ self.match[None, ..., :self.array_used]
@@ -109,9 +153,29 @@ class U1XToU1X:
         self.match[..., :self.array_used][1, :, ~diffed_neg_mask] &= neg_case
 
         new_cases = diff[new_case_mask]
+        new_case_groups = pending_groups[new_case_mask]
+
+        if new_cases.shape[0]:
+            kept = np.ones(new_cases.shape[0], dtype=np.bool_)
+            fresh_group_used = False
+            for idx, groups in enumerate(new_case_groups):
+                if groups.any():
+                    continue
+
+                if (not fresh_group_used) and self.group_used < self.group_size:
+                    groups[self.group_used] = True
+                    self.group_used += 1
+                    fresh_group_used = True
+                else:
+                    kept[idx] = False
+
+            new_cases = new_cases[kept]
+            new_case_groups = new_case_groups[kept]
 
         assert self.array_used + new_cases.shape[0] <= self.array_size
         self.match[..., self.array_used:self.array_used+new_cases.shape[0]] = np.permute_dims(new_cases, (1,2,0))
         self.match[1, :, self.array_used:self.array_used+new_cases.shape[0]] &= neg_case[..., None]
+        self.emit[self.array_used:self.array_used+new_cases.shape[0]] = new_case_groups
 
         self.array_used += new_cases.shape[0]
+        self._pending_diff_groups = np.zeros((0, self.group_size), dtype=np.bool_)

--- a/src/tests.py
+++ b/src/tests.py
@@ -13,9 +13,11 @@ def format_debug_stats(neur: U1XToU1X, prefix: str = "debug") -> str:
         f"inputs={stats['total_inputs']} "
         f"diffs={stats['total_diffs']} "
         f"cases={stats['active_cases']} "
+        f"groups={stats['active_groups']} "
         f"avg_diffs/input={stats['avg_diffs_per_input']:.4f} "
         f"avg_case_acts/input={stats['avg_case_activations_per_input']:.4f} "
-        f"mean_acts/case={stats['mean_activations_per_case']:.2f}"
+        f"mean_acts/case={stats['mean_activations_per_case']:.2f} "
+        f"mean_cases/group={stats['mean_cases_per_group']:.2f}"
     )
 
 
@@ -25,7 +27,7 @@ def print_debug_stats(neur: U1XToU1X, prefix: str = "debug") -> None:
 
 def sanity_test():
 
-    eliv = U1XToU1X(np.empty(4, dtype=np.uint8), cases=6)
+    eliv = U1XToU1X(np.empty(4, dtype=np.uint8), cases=6, groups=6)
 
     temp = np.array([[8, 0, 0, 0], [2,0,0,0], [4,0,0,0]], dtype=np.uint8)
 
@@ -113,7 +115,7 @@ def dataset(
 
     # we love setup being 4 seconds out of 28 second runtime on the poor laptop
 
-    neur = U1XToU1X(np.empty(tiles_train.shape[2], tiles_train.dtype), cases=100_000) # case count inflated as chunking code was swapped for 7x7 tiles instead of 4x4
+    neur = U1XToU1X(np.empty(tiles_train.shape[2], tiles_train.dtype), cases=100_000, groups=100_000) # case count inflated as chunking code was swapped for 7x7 tiles instead of 4x4
 
     counter = 0
 

--- a/src/tests.py
+++ b/src/tests.py
@@ -48,6 +48,8 @@ def dataset(
     report_every: int = 1000,
     reporter: Callable[[str], None] | None = print,
     reset_stats_between_stages: bool = True,
+    shuffle_train: bool = False,
+    shuffle_seed: int | None = None,
 ):
     import tensorflow_datasets as tfds
 
@@ -107,6 +109,15 @@ def dataset(
     tiles_train = recast_u64(tiles_train)
     tiles_eval = recast_u64(tiles_eval)
 
+    if shuffle_train:
+        rng = np.random.default_rng(shuffle_seed)
+        permutation = rng.permutation(tiles_train.shape[0])
+        tiles_train = tiles_train[permutation]
+
+        if reporter:
+            seed_display = shuffle_seed if shuffle_seed is not None else "random"
+            reporter(f"Shuffled training dataset order with seed={seed_display}")
+
     all_tiles_train = tiles_train.reshape(tiles_train.shape[0] * tiles_train.shape[1], tiles_train.shape[2])
     all_tiles = np.unique(all_tiles_train, axis=0)
     if reporter:
@@ -134,7 +145,7 @@ def dataset(
 
     if reporter:
         reporter(format_debug_stats(neur, prefix="train-final"))
-        reporter(f"\n\n{neur.array_used} cases used!\nMoving into validation\n")
+        reporter(f"\n\n{neur.array_used} cases used! {neur.group_used} groups used!\nMoving into validation\n")
     # 811 as is
 
     if reset_stats_between_stages:
@@ -158,6 +169,38 @@ def dataset(
     return neur, misses
 
 
+def dataset_shuffle_trials(
+    reruns: int,
+    report_every: int,
+    reporter: Callable[[str], None] | None,
+    reset_stats_between_stages: bool,
+    shuffle_seed: int | None,
+) -> list[tuple[int, int, int]]:
+    summaries: list[tuple[int, int, int]] = []
+
+    for run in range(reruns):
+        run_seed = None if shuffle_seed is None else shuffle_seed + run
+        if reporter:
+            reporter(f"\n=== shuffled run {run + 1}/{reruns} ===")
+
+        neur, misses = dataset(
+            report_every=report_every,
+            reporter=reporter,
+            reset_stats_between_stages=reset_stats_between_stages,
+            shuffle_train=True,
+            shuffle_seed=run_seed,
+        )
+
+        summaries.append((neur.array_used, neur.group_used, misses))
+
+        if reporter:
+            reporter(
+                f"run {run + 1} summary: cases={neur.array_used} groups={neur.group_used} misses={misses}"
+            )
+
+    return summaries
+
+
 def main() -> None:
     parser = argparse.ArgumentParser(description="Run NN structural engine diagnostics")
     parser.add_argument("--mode", choices=("dataset", "sanity"), default="dataset")
@@ -172,17 +215,53 @@ def main() -> None:
         action="store_true",
         help="Keep debug counters cumulative across training and evaluation.",
     )
+    parser.add_argument(
+        "--shuffle-train",
+        action="store_true",
+        help="Shuffle training dataset order before training.",
+    )
+    parser.add_argument(
+        "--shuffle-seed",
+        type=int,
+        default=None,
+        help="Seed for training shuffle order. If omitted, uses random order.",
+    )
+    parser.add_argument(
+        "--reruns",
+        type=int,
+        default=1,
+        help="Number of times to rerun dataset mode (useful with --shuffle-train).",
+    )
     args = parser.parse_args()
 
     if args.mode == "sanity":
         sanity_test()
         return
 
-    dataset(
+    if args.reruns < 1:
+        raise ValueError("--reruns must be >= 1")
+
+    if args.reruns == 1:
+        dataset(
+            report_every=args.report_every,
+            reporter=print,
+            reset_stats_between_stages=not args.no_reset_between_stages,
+            shuffle_train=args.shuffle_train,
+            shuffle_seed=args.shuffle_seed,
+        )
+        return
+
+    summaries = dataset_shuffle_trials(
+        reruns=args.reruns,
         report_every=args.report_every,
         reporter=print,
         reset_stats_between_stages=not args.no_reset_between_stages,
+        shuffle_seed=args.shuffle_seed,
     )
+
+    print("\n=== rerun summary ===")
+    for run, (cases, groups, misses) in enumerate(summaries, start=1):
+        print(f"run {run}: cases={cases} groups={groups} misses={misses}")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Motivation
- Provide visibility into group-level activity so grouping stability can be monitored alongside case activation metrics.
- Surface the number of non-empty groups and the mean membership per active group to help detect case/group explosion or consolidation regressions.

### Description
- Compute `active_groups` and `mean_cases_per_group` in `U1XToU1X.debug_snapshot()` by counting non-empty columns in `self.emit[:self.array_used, :self.group_used]` and averaging non-zero group counts.
- Add these two metrics to the dictionary returned by `debug_snapshot()` as `"active_groups"` and `"mean_cases_per_group"`.
- Include the new metrics in the formatted debug output string in `src/tests.py` as `groups=...` and `mean_cases/group=...`.

### Testing
- Ran `python src/tests.py --mode sanity`, which completed successfully and printed the expected sanity run outputs (`1`, `3`, `3`).
- Ran `python -m py_compile src/neurrayv4.py src/tests.py src/neurtypes.py`, which succeeded with no syntax errors.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699129cc6e0083259de27f2c8eec2438)