### PR TITLE
Add NNv5 7x7 -> packed u64 encoder and dataset 7x7 block-mode integration

### DIFF
--- a/src/nnv5_u64_dtype.py
+++ b/src/nnv5_u64_dtype.py
@@ -1,0 +1,271 @@
+"""NNv5 7x7 grayscale -> structured 64-bit encoder.
+
+This module defines a hand-authored, block-structured datatype for NNv5 inputs.
+It is intentionally *not* a reconstruction-focused image codec. The purpose is to
+present reusable, overlapping local propositions that can co-fire and be grouped
+by the rule engine with lower novelty pressure than raw bitpacked pixels.
+
+Bit layout (per 16-bit block)
+-----------------------------
+Each encoded 7x7 image uses 4 overlapping 4x4 blocks. Every block emits 16 bits:
+
+- Bits 0..2  : local floor bucket (3 bits)
+- Bits 3..5  : threshold ladder on normalized values (>=T1, >=T2, >=T3)
+- Bit 6      : top half brighter than bottom half
+- Bit 7      : left half brighter than right half
+- Bit 8      : main diagonal stronger than off-diagonal
+- Bit 9      : single dominant hotspot exists
+- Bit 10     : near-uniform normalized block
+- Bit 11     : multiple raised cells (at least 2 cells >= T2)
+- Bit 12     : vertical gradient cue present
+- Bit 13     : horizontal gradient cue present
+- Bit 14     : corner-weighted structure present
+- Bit 15     : exceed/saturation detail flag
+
+64-bit word composition
+-----------------------
+- bits 0..15   = block 0 (rows 0..3, cols 0..3)
+- bits 16..31  = block 1 (rows 0..3, cols 3..6)
+- bits 32..47  = block 2 (rows 3..6, cols 0..3)
+- bits 48..63  = block 3 (rows 3..6, cols 3..6)
+
+The code is structured so the block schema can be reused for future 128-bit
+variants by adding more block coordinates while keeping the same 16-bit local
+descriptor.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import numpy as np
+
+# -----------------------------
+# Tunable encoding constants
+# -----------------------------
+FLOOR_BUCKET_SIZE = 32
+THRESH_T1 = 16
+THRESH_T2 = 48
+THRESH_T3 = 96
+EPSILON = 4.0
+
+# Extra cues/guards for relational bits.
+HOTSPOT_MIN = 80.0
+HOTSPOT_GAP = 24.0
+UNIFORM_STD_MAX = 8.0
+UNIFORM_RANGE_MAX = 24.0
+GRAD_ROW_STEP = 6.0
+GRAD_COL_STEP = 6.0
+CORNER_ENERGY_MARGIN = 24.0
+EXCEED_RANGE = 144.0
+EXCEED_STD = 42.0
+
+# 4 overlapping windows over 7x7.
+BLOCK_SLICES: tuple[tuple[slice, slice], ...] = (
+    (slice(0, 4), slice(0, 4)),
+    (slice(0, 4), slice(3, 7)),
+    (slice(3, 7), slice(0, 4)),
+    (slice(3, 7), slice(3, 7)),
+)
+
+BIT_NAMES: dict[int, str] = {
+    0: "floor_bucket_bit0",
+    1: "floor_bucket_bit1",
+    2: "floor_bucket_bit2",
+    3: "any_ge_t1",
+    4: "any_ge_t2",
+    5: "any_ge_t3",
+    6: "top_brighter_than_bottom",
+    7: "left_brighter_than_right",
+    8: "main_diag_stronger_than_off_diag",
+    9: "single_dominant_hotspot",
+    10: "near_uniform",
+    11: "multiple_raised_cells",
+    12: "vertical_gradient_present",
+    13: "horizontal_gradient_present",
+    14: "corner_weighted_structure",
+    15: "exceed_saturation",
+}
+
+
+def _to_image_array(image: Any) -> np.ndarray:
+    """Validate/coerce input into a 7x7 float32 array in [0, 255]."""
+    arr = np.asarray(image)
+    if arr.shape != (7, 7):
+        raise ValueError(f"Expected shape (7, 7), got {arr.shape}")
+
+    arr = arr.astype(np.float32, copy=False)
+    if np.any(arr < 0) or np.any(arr > 255):
+        raise ValueError("Input values must be within [0, 255]")
+    return arr
+
+
+def _to_batch_array(images: Any) -> np.ndarray:
+    """Validate/coerce input into a (N, 7, 7) float32 array in [0, 255]."""
+    arr = np.asarray(images)
+    if arr.ndim != 3 or arr.shape[1:] != (7, 7):
+        raise ValueError(f"Expected batch shape (N, 7, 7), got {arr.shape}")
+    arr = arr.astype(np.float32, copy=False)
+    if np.any(arr < 0) or np.any(arr > 255):
+        raise ValueError("Input values must be within [0, 255]")
+    return arr
+
+
+def _extract_overlapping_blocks(batch: np.ndarray) -> np.ndarray:
+    """Extract all 4 overlapping 4x4 windows. Output shape: (N, 4, 4, 4)."""
+    return np.stack(
+        [batch[:, rs, cs] for rs, cs in BLOCK_SLICES],
+        axis=1,
+    )
+
+
+def _encode_blocks_to_u16(blocks: np.ndarray) -> np.ndarray:
+    """Vectorized encoding of blocks with shape (M, 4, 4) into uint16 descriptors."""
+    floor_vals = np.min(blocks, axis=(1, 2))
+    norm = blocks - floor_vals[:, None, None]
+
+    bits = np.clip((floor_vals // FLOOR_BUCKET_SIZE).astype(np.int32), 0, 7).astype(np.uint16)
+
+    # Bits 3..5: threshold ladder
+    bits |= (np.any(norm >= THRESH_T1, axis=(1, 2)).astype(np.uint16) << np.uint16(3))
+    bits |= (np.any(norm >= THRESH_T2, axis=(1, 2)).astype(np.uint16) << np.uint16(4))
+    bits |= (np.any(norm >= THRESH_T3, axis=(1, 2)).astype(np.uint16) << np.uint16(5))
+
+    # Bit 6: top brighter than bottom
+    top_mean = np.mean(norm[:, 0:2, :], axis=(1, 2))
+    bottom_mean = np.mean(norm[:, 2:4, :], axis=(1, 2))
+    bits |= ((top_mean > (bottom_mean + EPSILON)).astype(np.uint16) << np.uint16(6))
+
+    # Bit 7: left brighter than right
+    left_mean = np.mean(norm[:, :, 0:2], axis=(1, 2))
+    right_mean = np.mean(norm[:, :, 2:4], axis=(1, 2))
+    bits |= ((left_mean > (right_mean + EPSILON)).astype(np.uint16) << np.uint16(7))
+
+    # Bit 8: main diagonal (quadrants) stronger than off diagonal
+    q_tl = np.sum(norm[:, 0:2, 0:2], axis=(1, 2))
+    q_tr = np.sum(norm[:, 0:2, 2:4], axis=(1, 2))
+    q_bl = np.sum(norm[:, 2:4, 0:2], axis=(1, 2))
+    q_br = np.sum(norm[:, 2:4, 2:4], axis=(1, 2))
+    bits |= ((((q_tl + q_br) > (q_tr + q_bl + EPSILON)).astype(np.uint16)) << np.uint16(8))
+
+    # Bit 9: single dominant hotspot
+    flat_sorted = np.sort(norm.reshape(norm.shape[0], -1), axis=1)
+    peak = flat_sorted[:, -1]
+    second = flat_sorted[:, -2]
+    hotspot = (peak >= HOTSPOT_MIN) & ((peak - second) >= HOTSPOT_GAP)
+    bits |= (hotspot.astype(np.uint16) << np.uint16(9))
+
+    # Bit 10: near-uniform
+    norm_std = np.std(norm, axis=(1, 2))
+    norm_range = np.max(norm, axis=(1, 2)) - np.min(norm, axis=(1, 2))
+    uniform = (norm_std <= UNIFORM_STD_MAX) & (norm_range <= UNIFORM_RANGE_MAX)
+    bits |= (uniform.astype(np.uint16) << np.uint16(10))
+
+    # Bit 11: multiple raised cells (>=2 at T2)
+    raised = np.count_nonzero(norm >= THRESH_T2, axis=(1, 2)) >= 2
+    bits |= (raised.astype(np.uint16) << np.uint16(11))
+
+    # Bit 12: vertical gradient
+    row_means = np.mean(norm, axis=2)
+    vgrad = (row_means[:, 3] - row_means[:, 0]) >= GRAD_ROW_STEP
+    bits |= (vgrad.astype(np.uint16) << np.uint16(12))
+
+    # Bit 13: horizontal gradient
+    col_means = np.mean(norm, axis=1)
+    hgrad = (col_means[:, 3] - col_means[:, 0]) >= GRAD_COL_STEP
+    bits |= (hgrad.astype(np.uint16) << np.uint16(13))
+
+    # Bit 14: corner weighted
+    corners = norm[:, 0, 0] + norm[:, 0, 3] + norm[:, 3, 0] + norm[:, 3, 3]
+    interior = norm[:, 1, 1] + norm[:, 1, 2] + norm[:, 2, 1] + norm[:, 2, 2]
+    corner_weighted = corners > (interior + CORNER_ENERGY_MARGIN)
+    bits |= (corner_weighted.astype(np.uint16) << np.uint16(14))
+
+    # Bit 15: exceed/saturation flag
+    exceed = (norm_range >= EXCEED_RANGE) | (norm_std >= EXCEED_STD)
+    bits |= (exceed.astype(np.uint16) << np.uint16(15))
+
+    return bits
+
+
+def encode_7x7_to_u64(image: Any) -> int:
+    """Encode one 7x7 grayscale sample into a packed 64-bit Python int."""
+    arr = _to_image_array(image)
+    return int(encode_batch(arr[None, ...])[0])
+
+
+def decode_u64_fields(code: int) -> dict[str, Any]:
+    """Decode packed code into block-level fields for debugging and inspection."""
+    value = int(code) & ((1 << 64) - 1)
+
+    blocks: list[dict[str, Any]] = []
+    for block_idx in range(4):
+        raw = (value >> (16 * block_idx)) & 0xFFFF
+        floor_bucket = raw & 0b111
+
+        bits = {name: bool((raw >> bit) & 1) for bit, name in BIT_NAMES.items() if bit >= 3}
+
+        blocks.append(
+            {
+                "block_index": block_idx,
+                "rows": (BLOCK_SLICES[block_idx][0].start, BLOCK_SLICES[block_idx][0].stop - 1),
+                "cols": (BLOCK_SLICES[block_idx][1].start, BLOCK_SLICES[block_idx][1].stop - 1),
+                "raw_u16": raw,
+                "floor_bucket": floor_bucket,
+                "floor_range": (floor_bucket * FLOOR_BUCKET_SIZE, floor_bucket * FLOOR_BUCKET_SIZE + 31),
+                "bits": bits,
+            }
+        )
+
+    return {
+        "u64": value,
+        "u64_hex": f"0x{value:016x}",
+        "blocks": blocks,
+        "schema": {
+            "thresholds": {"T1": THRESH_T1, "T2": THRESH_T2, "T3": THRESH_T3},
+            "epsilon": EPSILON,
+            "block_slices": [
+                ((rs.start, rs.stop - 1), (cs.start, cs.stop - 1)) for rs, cs in BLOCK_SLICES
+            ],
+        },
+    }
+
+
+def encode_batch(images: Any) -> np.ndarray:
+    """Encode a batch of images into uint64 array of shape (N,)."""
+    batch = _to_batch_array(images)
+    blocks = _extract_overlapping_blocks(batch)                # (N, 4, 4, 4)
+    flat_blocks = blocks.reshape(blocks.shape[0] * 4, 4, 4)    # (N*4, 4, 4)
+
+    block_codes = _encode_blocks_to_u16(flat_blocks).reshape(blocks.shape[0], 4).astype(np.uint64)
+    shifts = np.array([0, 16, 32, 48], dtype=np.uint64)
+    encoded = np.left_shift(block_codes, shifts[None, :])
+    return np.sum(encoded, axis=1, dtype=np.uint64)
+
+
+def demo_self_test() -> dict[str, Any]:
+    """Small deterministic helper for quick manual inspection."""
+    demo = np.array(
+        [
+            [0, 0, 8, 16, 16, 8, 0],
+            [0, 12, 40, 88, 88, 40, 12],
+            [8, 36, 96, 180, 180, 96, 36],
+            [16, 88, 180, 255, 255, 180, 88],
+            [8, 36, 96, 180, 180, 96, 36],
+            [0, 12, 40, 88, 88, 40, 12],
+            [0, 0, 8, 16, 16, 8, 0],
+        ],
+        dtype=np.uint8,
+    )
+    code = encode_7x7_to_u64(demo)
+    return decode_u64_fields(code)
+
+
+if __name__ == "__main__":
+    report = demo_self_test()
+    print(report["u64_hex"])
+    for block in report["blocks"]:
+        print(
+            f"block={block['block_index']} raw=0x{block['raw_u16']:04x} "
+            f"floor_bucket={block['floor_bucket']}"
+        )

--- a/src/tests.py
+++ b/src/tests.py
@@ -4,6 +4,7 @@ from collections.abc import Callable
 import numpy as np
 
 from neurrayv4 import U1XToU1X
+from nnv5_u64_dtype import encode_batch as encode_7x7_batch_to_u64
 
 
 def format_debug_stats(neur: U1XToU1X, prefix: str = "debug") -> str:
@@ -54,6 +55,7 @@ def dataset(
     report_every: int = 1000,
     reporter: Callable[[str], None] | None = print,
     reset_stats_between_stages: bool = True,
+    block_mode: str = "4x4",
 ):
     import tensorflow_datasets as tfds
 
@@ -73,45 +75,57 @@ def dataset(
     x_train, y_train = train_np
     x_test, y_test   = test_np
 
-    def chunk_mnist_for_U1X(x: np.ndarray) -> np.ndarray:
+    def chunk_mnist_for_U1X(x: np.ndarray, mode: str) -> np.ndarray:
         """
         x: numpy array of shape (N, 28, 28)
-        returns: (N, 4, 4, 7, 7)
+        returns:
+            mode="4x4" -> (N, 49, 16), where each token is a 4x4 block (16 bytes)
+            mode="7x7" -> (N, 16, 49), where each token is a 7x7 block (49 bytes)
         """
         N, H, W, _ = x.shape
         assert H == 28 and W == 28
 
-        # reshape + transpose trick
-        tiles = (
-            x
-            .reshape(N, 4, 7, 4, 7)
-            .transpose(0, 1, 3, 2, 4)
-        )
+        if mode == "4x4":
+            # Create a 7x7 grid of 4x4 blocks.
+            # (N, 28, 28, 1) -> (N, 7, 4, 7, 4) -> (N, 7, 7, 4, 4)
+            tiles = x.reshape(N, 7, 4, 7, 4).transpose(0, 1, 3, 2, 4)
+            # flatten 4x4 -> 16 bytes
+            tiles = tiles.reshape(tiles.shape[0], 7, 7, -1)            # (N, 7, 7, 16)
+            # reorder to token-major and flatten grid 7x7 -> 49 tokens
+            tiles = tiles.reshape(tiles.shape[0], -1, tiles.shape[-1])  # (N, 49, 16)
+            return tiles
 
-        # flatten 7x7
-        tiles = tiles.reshape(tiles.shape[0], 4, 4, -1)    # (N,4,4,49)
+        if mode == "7x7":
+            # Create a 4x4 grid of 7x7 blocks.
+            # (N, 28, 28, 1) -> (N, 4, 7, 4, 7) -> (N, 4, 4, 7, 7)
+            tiles = x.reshape(N, 4, 7, 4, 7).transpose(0, 1, 3, 2, 4)
+            # Run the NNv5 structured encoder over each 7x7 block.
+            # (N, 4, 4, 7, 7) -> (N * 16, 7, 7) -> encode -> (N, 16, 1)
+            tiles = tiles.reshape(tiles.shape[0], 16, 7, 7)
+            flat_tiles = tiles.reshape(tiles.shape[0] * tiles.shape[1], 7, 7)
+            encoded = encode_7x7_batch_to_u64(flat_tiles)
+            tiles = encoded.reshape(tiles.shape[0], tiles.shape[1], 1)
+            return tiles
 
-        # reorder to tokens
-        tiles = tiles.transpose(0, 3, 1, 2)                # (N,49,4,4)
+        raise ValueError(f"Unsupported block_mode: {mode}. Use '4x4' or '7x7'.")
 
-        # now flatten 4x4 to 16 tokens
-        tiles = tiles.reshape(tiles.shape[0], tiles.shape[1], -1)  # (N,49,16)
-
-        return tiles
-
-    def recast_u64(a:np.ndarray) -> np.ndarray:
+    def recast_u64(a: np.ndarray) -> np.ndarray:
         a = np.ascontiguousarray(a)
-
+        trailing = a.shape[-1]
+        remainder = trailing % 8
+        if remainder != 0:
+            pad = 8 - remainder
+            a = np.pad(a, [(0, 0)] * (a.ndim - 1) + [(0, pad)], mode="constant")
         b = a.view(np.uint64)
-        b = b.reshape(*a.shape[:-1], 2)
+        b = b.reshape(*a.shape[:-1], a.shape[-1] // 8)
         return b
 
-    # `tiles` is from your chunking function, shape (N, 4, 4, 7, 7)
-    tiles_train = chunk_mnist_for_U1X(x_train)
-    tiles_eval = chunk_mnist_for_U1X(x_test)
+    tiles_train = chunk_mnist_for_U1X(x_train, mode=block_mode)
+    tiles_eval = chunk_mnist_for_U1X(x_test, mode=block_mode)
 
-    tiles_train = recast_u64(tiles_train)
-    tiles_eval = recast_u64(tiles_eval)
+    if block_mode == "4x4":
+        tiles_train = recast_u64(tiles_train)
+        tiles_eval = recast_u64(tiles_eval)
 
     print(tiles_train.shape)
     gen = np.random.default_rng()
@@ -127,7 +141,7 @@ def dataset(
 
     # we love setup being 4 seconds out of 28 second runtime on the poor laptop
 
-    neur = U1XToU1X(np.empty(tiles_train.shape[2], tiles_train.dtype), cases=100_000, groups=40) # case count inflated as chunking code was swapped for 7x7 tiles instead of 4x4
+    neur = U1XToU1X(np.empty(tiles_train.shape[2], tiles_train.dtype), cases=100_000, groups=40)
 
     counter = 0
 
@@ -176,6 +190,12 @@ def main() -> None:
     parser = argparse.ArgumentParser(description="Run NN structural engine diagnostics")
     parser.add_argument("--mode", choices=("dataset", "sanity"), default="dataset")
     parser.add_argument(
+        "--block-mode",
+        choices=("4x4", "7x7"),
+        default="4x4",
+        help="Dataset block extraction mode: 4x4 blocks in a 7x7 grid or 7x7 blocks in a 4x4 grid.",
+    )
+    parser.add_argument(
         "--report-every",
         type=int,
         default=1000,
@@ -196,6 +216,7 @@ def main() -> None:
         report_every=args.report_every,
         reporter=print,
         reset_stats_between_stages=not args.no_reset_between_stages,
+        block_mode=args.block_mode,
     )
 
 


### PR DESCRIPTION
### Motivation

- Provide a hand-authored, block-structured 64-bit encoding for 7x7 grayscale patches to expose local, overlapping structural cues instead of raw bitpacked pixels.
- Allow the dataset pipeline to optionally produce NNv5-style 7x7 tokens so the rule engine can operate on compact structured descriptors.

### Description

- Add `src/nnv5_u64_dtype.py` which implements a reusable 16-bit-per-block descriptor and a 4-block composition into a packed 64-bit word, including tunable thresholds and bit definitions, vectorized batch encoding via `encode_batch`, single-sample `encode_7x7_to_u64`, and a debug `decode_u64_fields`/`demo_self_test`.
- Update `src/tests.py` to import the encoder as `encode_7x7_batch_to_u64`, add a `--block-mode` CLI option (`4x4` or `7x7`), and implement dual chunking logic in `chunk_mnist_for_U1X` that either emits `(N,49,16)` 4x4 tokens or encodes `(N,16,1)` NNv5 7x7 tokens using the new encoder.
- Improve `recast_u64` to pad trailing bytes to an 8-byte boundary and reshape safely into `uint64` views for downstream code.

### Testing

- Ran the module-level self-check `demo_self_test()` in `nnv5_u64_dtype.py`, which produced a deterministic `u64` hex and per-block decoded fields as expected.
- Executed the repository diagnostics in `src/tests.py` in `sanity` mode using `--mode sanity` to exercise small forward/assign flows, which completed successfully.
- Performed a limited dataset run of `src/tests.py` with both `--block-mode 4x4` and `--block-mode 7x7` to verify chunking, padding, encoding, and the `U1XToU1X` training loop integration, and observed runs to completion without assertion failures.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c22c64b0188325a28c05b176a3f3f4)